### PR TITLE
Region not retained and past execution disabled issue in execution history

### DIFF
--- a/src/components/common/dateCalendar/CustomDate.tsx
+++ b/src/components/common/dateCalendar/CustomDate.tsx
@@ -32,6 +32,7 @@ export default function CustomDate(props: ICustomDateProps) {
     redListDates,
     greenListDates,
     darkGreenListDates,
+    isLoading,
     ...dateProps
   } = props;
   const { day, disabled } = dateProps;
@@ -161,7 +162,7 @@ export default function CustomDate(props: ICustomDateProps) {
           transition: 'none'
         }}
       />
-      {dateInfo.StatusIcon && !dateInfo.isSelected && (
+      {dateInfo.StatusIcon && !dateInfo.isSelected && !isLoading && (
         <div
           className={
             day.date() > 9

--- a/src/components/common/dateCalendar/DateCalendar.tsx
+++ b/src/components/common/dateCalendar/DateCalendar.tsx
@@ -31,7 +31,8 @@ const ExecutionCalendar = ({
   greyListDates,
   redListDates,
   greenListDates,
-  darkGreenListDates
+  darkGreenListDates,
+  isLoading
 }: any) => (
   <div className="execution-history-left-wrapper calender-top execution-wrapper-border-none">
     <LocalizationProvider dateAdapter={AdapterDayjs}>
@@ -49,7 +50,8 @@ const ExecutionCalendar = ({
             greyListDates,
             redListDates,
             greenListDates,
-            darkGreenListDates
+            darkGreenListDates,
+            isLoading
           }
         }}
       />

--- a/src/components/common/dateCalendar/mui.d.ts
+++ b/src/components/common/dateCalendar/mui.d.ts
@@ -37,5 +37,6 @@ declare module '@mui/x-date-pickers/PickersDay' {
     redListDates?: string[];
     greenListDates?: string[];
     darkGreenListDates?: string[];
+    isLoading?: boolean;
   }
 }

--- a/src/components/vertex/vertexExecutionHistoryView/VertexExecutionHistory.tsx
+++ b/src/components/vertex/vertexExecutionHistoryView/VertexExecutionHistory.tsx
@@ -23,7 +23,7 @@ import ExecutionCalendar from '../../common/dateCalendar/DateCalendar';
 import VertexScheduleRuns from '../vertexExecutionHistoryView/VertexScheduleRuns';
 import { VertexServices } from '../../../services/vertex/VertexServices';
 import { IScheduleRun } from '../../../interfaces/VertexInterface';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { abortApiCall } from '../../../utils/Config';
 
 const VertexExecutionHistory = ({
@@ -32,13 +32,13 @@ const VertexExecutionHistory = ({
   abortControllers: any;
 }) => {
   const navigate = useNavigate();
-  const { scheduleId, region, scheduleName } = useParams();
+  const location = useLocation();
+  const { scheduleId, region, scheduleName, createTime } = location.state;
   const currentDate = new Date().toLocaleDateString();
   const [fileExists, setFileExists] = useState<object>({});
 
   const {
     vertexScheduleRunsList,
-    createTime,
     selectedDate,
     isLoading,
     greyListDates,
@@ -65,7 +65,8 @@ const VertexExecutionHistory = ({
     darkGreenListDates,
     handleDateSelection,
     handleMonthChange,
-    handleLogs
+    handleLogs,
+    isLoading
   };
 
   const vertexScheduleRunProps = {

--- a/src/components/vertex/vertexListingView/ListVertexSchedule.tsx
+++ b/src/components/vertex/vertexListingView/ListVertexSchedule.tsx
@@ -331,11 +331,12 @@ const ListVertexSchedule = ({
     }
 
     // Converts the slashes and other special characters into a safe format that React Router will treat as a single string
-    const scheduleId = encodeURIComponent(schedulerData?.name.split('/').pop());
-    const selectedScheduleName = encodeURIComponent(schedulerData?.displayName);
-    navigate(
-      `/execution-vertex-history/${scheduleId}/${region}/${selectedScheduleName}`
-    );
+    const scheduleId = schedulerData?.name.split('/').pop();
+    const scheduleName = schedulerData?.displayName;
+    const createTime = schedulerData?.createTime;
+    navigate('/execution-vertex-history', {
+      state: { scheduleId, region, scheduleName, createTime }
+    });
   };
 
   /**

--- a/src/hooks/useVertexExecutionHistoryReducer.tsx
+++ b/src/hooks/useVertexExecutionHistoryReducer.tsx
@@ -52,8 +52,6 @@ const executionHistoryReducer = (state: any, action: any) => {
       return { ...state, scheduleId: action.payload };
     case 'SET_VERTEX_RUNS':
       return { ...state, vertexScheduleRunsList: action.payload };
-    case 'SET_CREATED_TIME':
-      return { ...state, createTime: action.payload };
     default:
       return state;
   }
@@ -70,8 +68,7 @@ const initialState = {
   redListDates: [],
   greenListDates: [],
   darkGreenListDates: [],
-  projectId: '',
-  createTime: ''
+  projectId: ''
 };
 
 export const useExecutionHistory = (
@@ -103,15 +100,6 @@ export const useExecutionHistory = (
       dispatch({
         type: 'SET_VERTEX_RUNS',
         payload: executionData.scheduleRuns
-      });
-
-      dispatch({
-        type: 'SET_CREATED_TIME',
-        payload:
-          executionData.scheduleRuns.length > 0
-            ? executionData.scheduleRuns[executionData.scheduleRuns.length - 1]
-                .createTime
-            : ''
       });
     }
   };

--- a/src/interfaces/VertexInterface.ts
+++ b/src/interfaces/VertexInterface.ts
@@ -391,6 +391,7 @@ export interface ICustomDateProps extends PickersDayProps<Dayjs> {
   redListDates?: string[];
   greenListDates?: string[];
   darkGreenListDates?: string[];
+  isLoading?: boolean;
 }
 
 export interface IVertexListingInputProps {

--- a/src/router/SchedulerRoutes.tsx
+++ b/src/router/SchedulerRoutes.tsx
@@ -113,7 +113,7 @@ export function SchedulerRoutes(schedulerRouteProps: ISchedulerRoutesProps) {
           />
         </Route>
         <Route
-          path="/execution-vertex-history/:scheduleId/:region/:scheduleName"
+          path="/execution-vertex-history"
           element={
             <Suspense
               fallback={


### PR DESCRIPTION
Region is retained when navigating from vertex execution history to listing screen fixed. Previous date disabled for schedule execution if it exist issue fixed.

Bug:
http://b/442761681 Region not retained when navigating back to vertex listing screen from vertex execution history
http://b/442777934 Vertex execution history previous dates disabled